### PR TITLE
[feat/TK-128] 지출 세부 내역 조회 API 구현

### DIFF
--- a/src/main/java/withbeetravel/controller/SettlementController.java
+++ b/src/main/java/withbeetravel/controller/SettlementController.java
@@ -1,0 +1,22 @@
+package withbeetravel.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import withbeetravel.dto.settlement.ShowSettlementDetailResponse;
+import withbeetravel.service.settlement.SettlementService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/travels/{travelId}/settlements")
+public class SettlementController {
+    private final SettlementService settlementService;
+
+    @GetMapping("/{settlementId}")
+    ShowSettlementDetailResponse getSettlementDetails(@PathVariable Long travelId, @PathVariable Long settlementId) {
+        Long userId = 1L;
+        return settlementService.getSettlementDetails(userId, travelId, settlementId);
+    }
+}

--- a/src/main/java/withbeetravel/domain/SharedPayment.java
+++ b/src/main/java/withbeetravel/domain/SharedPayment.java
@@ -35,10 +35,10 @@ public class SharedPayment {
     private int paymentAmount;
 
     @Column(name = "foreign_payment_amount")
-    private double foreignPaymentAmount;
+    private Double foreignPaymentAmount;
 
     @Column(name = "exchange_rate")
-    private double exchangeRate;
+    private Double exchangeRate;
 
     @Column(name = "payment_comment")
     private String paymentComment;
@@ -68,8 +68,8 @@ public class SharedPayment {
                          Travel travel,
                          CurrencyUnit currencyUnit,
                          int paymentAmount,
-                         double foreignPaymentAmount,
-                         double exchangeRate,
+                         Double foreignPaymentAmount,
+                         Double exchangeRate,
                          String paymentComment,
                          String paymentImage,
                          boolean isManuallyAdded,

--- a/src/main/java/withbeetravel/domain/TravelMemberSettlementHistory.java
+++ b/src/main/java/withbeetravel/domain/TravelMemberSettlementHistory.java
@@ -26,10 +26,10 @@ public class TravelMemberSettlementHistory {
     private TravelMember travelMember;
 
     @Column(name = "own_payment_cost", nullable = false)
-    private double ownPaymentCost;
+    private int ownPaymentCost;
 
     @Column(name = "actual_burden_cost", nullable = false)
-    private double actualBurdenCost;
+    private int actualBurdenCost;
 
     @Column(name = "is_agreed", nullable = false)
     private boolean isAgreed;
@@ -38,8 +38,8 @@ public class TravelMemberSettlementHistory {
     public TravelMemberSettlementHistory(Long id,
                                          SettlementRequest settlementRequest,
                                          TravelMember travelMember,
-                                         double ownPaymentCost,
-                                         double actualBurdenCost,
+                                         int ownPaymentCost,
+                                         int actualBurdenCost,
                                          boolean isAgreed) {
         this.id = id;
         this.settlementRequest = settlementRequest;

--- a/src/main/java/withbeetravel/dto/settlement/ShowMyDetailPaymentResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowMyDetailPaymentResponse.java
@@ -1,0 +1,20 @@
+package withbeetravel.dto.settlement;
+
+import java.time.LocalDateTime;
+
+public class ShowMyDetailPaymentResponse {
+    private int paymentAmount;
+    private int requestedAmount;
+    private String storeName;
+    private LocalDateTime paymentDate;
+
+    private ShowMyDetailPaymentResponse(int paymentAmount,
+                                        int requestedAmount,
+                                        String storeName,
+                                        LocalDateTime paymentDate) {
+        this.paymentAmount = paymentAmount;
+        this.requestedAmount = requestedAmount;
+        this.storeName = storeName;
+        this.paymentDate = paymentDate;
+    }
+}

--- a/src/main/java/withbeetravel/dto/settlement/ShowMyDetailPaymentResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowMyDetailPaymentResponse.java
@@ -17,4 +17,8 @@ public class ShowMyDetailPaymentResponse {
         this.storeName = storeName;
         this.paymentDate = paymentDate;
     }
+
+    public static ShowMyDetailPaymentResponse of (int paymentAmount, int requestedAmount, String storeName, LocalDateTime paymentDate) {
+        return new ShowMyDetailPaymentResponse(paymentAmount, requestedAmount, storeName, paymentDate);
+    }
 }

--- a/src/main/java/withbeetravel/dto/settlement/ShowMyDetailPaymentResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowMyDetailPaymentResponse.java
@@ -1,7 +1,10 @@
 package withbeetravel.dto.settlement;
 
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 
+@Getter
 public class ShowMyDetailPaymentResponse {
     private int paymentAmount;
     private int requestedAmount;

--- a/src/main/java/withbeetravel/dto/settlement/ShowMyTotalPaymentResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowMyTotalPaymentResponse.java
@@ -10,4 +10,8 @@ public class ShowMyTotalPaymentResponse {
         this.ownPaymentCost = ownPaymentCost;
         this.actualBurdenCost = actualBurdenCost;
     }
+
+    public static ShowMyTotalPaymentResponse of (int totalPaymentCost, int ownPaymentCost, int actualBurdenCost) {
+        return new ShowMyTotalPaymentResponse(totalPaymentCost, ownPaymentCost, actualBurdenCost);
+    }
 }

--- a/src/main/java/withbeetravel/dto/settlement/ShowMyTotalPaymentResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowMyTotalPaymentResponse.java
@@ -1,0 +1,13 @@
+package withbeetravel.dto.settlement;
+
+public class ShowMyTotalPaymentResponse {
+    private int totalPaymentCost;
+    private int ownPaymentCost;
+    private int actualBurdenCost;
+
+    private ShowMyTotalPaymentResponse(int totalPaymentCost, int ownPaymentCost, int actualBurdenCost) {
+        this.totalPaymentCost = totalPaymentCost;
+        this.ownPaymentCost = ownPaymentCost;
+        this.actualBurdenCost = actualBurdenCost;
+    }
+}

--- a/src/main/java/withbeetravel/dto/settlement/ShowMyTotalPaymentResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowMyTotalPaymentResponse.java
@@ -1,5 +1,8 @@
 package withbeetravel.dto.settlement;
 
+import lombok.Getter;
+
+@Getter
 public class ShowMyTotalPaymentResponse {
     private int totalPaymentCost;
     private int ownPaymentCost;

--- a/src/main/java/withbeetravel/dto/settlement/ShowOtherSettlementResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowOtherSettlementResponse.java
@@ -1,0 +1,11 @@
+package withbeetravel.dto.settlement;
+
+public class ShowOtherSettlementResponse {
+    private String name;
+    private int actualBurdenCost;
+
+    public ShowOtherSettlementResponse(String name, int actualBurdenCost) {
+        this.name = name;
+        this.actualBurdenCost = actualBurdenCost;
+    }
+}

--- a/src/main/java/withbeetravel/dto/settlement/ShowOtherSettlementResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowOtherSettlementResponse.java
@@ -1,5 +1,9 @@
 package withbeetravel.dto.settlement;
 
+import lombok.Getter;
+
+@Getter
+
 public class ShowOtherSettlementResponse {
     private String name;
     private int totalPaymentCost;

--- a/src/main/java/withbeetravel/dto/settlement/ShowOtherSettlementResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowOtherSettlementResponse.java
@@ -2,10 +2,14 @@ package withbeetravel.dto.settlement;
 
 public class ShowOtherSettlementResponse {
     private String name;
-    private int actualBurdenCost;
+    private int totalPaymentCost;
 
-    public ShowOtherSettlementResponse(String name, int actualBurdenCost) {
+    private ShowOtherSettlementResponse(String name, int totalPaymentCost) {
         this.name = name;
-        this.actualBurdenCost = actualBurdenCost;
+        this.totalPaymentCost = totalPaymentCost;
+    }
+
+    public static ShowOtherSettlementResponse of (String name, int totalPaymentCost) {
+        return new ShowOtherSettlementResponse(name, totalPaymentCost);
     }
 }

--- a/src/main/java/withbeetravel/dto/settlement/ShowSettlementDetailResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowSettlementDetailResponse.java
@@ -1,0 +1,18 @@
+package withbeetravel.dto.settlement;
+
+import java.util.List;
+
+public class ShowSettlementDetailResponse {
+    private ShowMyTotalPaymentResponse myTotalPayment;
+    private List<ShowMyDetailPaymentResponse> myDetailPayments;
+    private List<ShowOtherSettlementResponse> others;
+
+    private ShowSettlementDetailResponse(
+            ShowMyTotalPaymentResponse myTotalPayment,
+            List<ShowMyDetailPaymentResponse> myDetailPayments,
+            List<ShowOtherSettlementResponse> others) {
+        this.myTotalPayment = myTotalPayment;
+        this.myDetailPayments = myDetailPayments;
+        this.others = others;
+    }
+}

--- a/src/main/java/withbeetravel/dto/settlement/ShowSettlementDetailResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowSettlementDetailResponse.java
@@ -1,7 +1,10 @@
 package withbeetravel.dto.settlement;
 
+import lombok.Getter;
+
 import java.util.List;
 
+@Getter
 public class ShowSettlementDetailResponse {
     private ShowMyTotalPaymentResponse myTotalPayment;
     private List<ShowMyDetailPaymentResponse> myDetailPayments;

--- a/src/main/java/withbeetravel/dto/settlement/ShowSettlementDetailResponse.java
+++ b/src/main/java/withbeetravel/dto/settlement/ShowSettlementDetailResponse.java
@@ -15,4 +15,11 @@ public class ShowSettlementDetailResponse {
         this.myDetailPayments = myDetailPayments;
         this.others = others;
     }
+
+    public static ShowSettlementDetailResponse of (
+            ShowMyTotalPaymentResponse myTotalPayment,
+            List<ShowMyDetailPaymentResponse> myDetailPayments,
+            List<ShowOtherSettlementResponse> others) {
+        return new ShowSettlementDetailResponse(myTotalPayment, myDetailPayments, others);
+    }
 }

--- a/src/main/java/withbeetravel/exception/error/SettlementErrorCode.java
+++ b/src/main/java/withbeetravel/exception/error/SettlementErrorCode.java
@@ -10,6 +10,7 @@ public class SettlementErrorCode extends ErrorCode{
     public static final SettlementErrorCode SETTLEMENT_ALREADY_AGREED = new SettlementErrorCode(HttpStatus.CONFLICT, "SETTLEMENT_ALREADY_AGREED", "SETTLEMENT-003", "이미 동의한 정산");
     public static final SettlementErrorCode SETTLEMENT_NOT_COMPLETED = new SettlementErrorCode(HttpStatus.CONFLICT, "SETTLEMENT_NOT_COMPLETED", "SETTLEMENT-005", "아직 정산 완료 되지 않음");
     public static final SettlementErrorCode NO_PERMISSION_TO_MANAGE_SETTLEMENT = new SettlementErrorCode(HttpStatus.FORBIDDEN, "NO_PERMISSION_TO_MANAGE_SETTLEMENT", "SETTLEMENT-006", "정산 관리 권한 없음");
+    public static final SettlementErrorCode MEMBER_SETTLEMENT_HISTORY_NOT_FOUND = new SettlementErrorCode(HttpStatus.NOT_FOUND, "MEMBER_SETTLEMENT_HISTORY_NOT_FOUND", "SETTLEMENT-007", "TRAVELMEMBER ID에 해당하는 여행 멤버 정산 내역 없음");
 
     private SettlementErrorCode(HttpStatus status, String name, String code, String message) {
         super(status, name, code, message);

--- a/src/main/java/withbeetravel/repository/PaymentParticipatedMemberRepository.java
+++ b/src/main/java/withbeetravel/repository/PaymentParticipatedMemberRepository.java
@@ -1,0 +1,9 @@
+package withbeetravel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import withbeetravel.domain.PaymentParticipatedMember;
+import java.util.List;
+
+public interface PaymentParticipatedMemberRepository extends JpaRepository<PaymentParticipatedMember, PaymentParticipatedMember> {
+    List<PaymentParticipatedMember> findAllByTravelMemberId(Long travelMemberId);
+}

--- a/src/main/java/withbeetravel/repository/SettlementRequestRepository.java
+++ b/src/main/java/withbeetravel/repository/SettlementRequestRepository.java
@@ -1,0 +1,7 @@
+package withbeetravel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import withbeetravel.domain.SettlementRequest;
+
+public interface SettlementRequestRepository extends JpaRepository<SettlementRequest, Long> {
+}

--- a/src/main/java/withbeetravel/repository/TravelMemberRepository.java
+++ b/src/main/java/withbeetravel/repository/TravelMemberRepository.java
@@ -1,0 +1,10 @@
+package withbeetravel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import withbeetravel.domain.TravelMember;
+
+import java.util.Optional;
+
+public interface TravelMemberRepository extends JpaRepository<TravelMember, Long> {
+    Optional<TravelMember> findByUserIdAndTravelId(Long userId, Long travelId);
+}

--- a/src/main/java/withbeetravel/repository/TravelMemberSettlementHistoryRepository.java
+++ b/src/main/java/withbeetravel/repository/TravelMemberSettlementHistoryRepository.java
@@ -1,0 +1,10 @@
+package withbeetravel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import withbeetravel.domain.TravelMemberSettlementHistory;
+
+import java.util.List;
+
+public interface TravelMemberSettlementHistoryRepository extends JpaRepository<TravelMemberSettlementHistory, Long> {
+    List<TravelMemberSettlementHistory> findAllBySettlementRequestId(Long settlementRequestId);
+}

--- a/src/main/java/withbeetravel/repository/TravelRepository.java
+++ b/src/main/java/withbeetravel/repository/TravelRepository.java
@@ -1,0 +1,7 @@
+package withbeetravel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import withbeetravel.domain.Travel;
+
+public interface TravelRepository extends JpaRepository<Travel, Long> {
+}

--- a/src/main/java/withbeetravel/service/settlement/SettlementService.java
+++ b/src/main/java/withbeetravel/service/settlement/SettlementService.java
@@ -1,8 +1,8 @@
 package withbeetravel.service.settlement;
 
-import withbeetravel.dto.settlement.ShowMyTotalPaymentResponse;
+import withbeetravel.dto.settlement.ShowSettlementDetailResponse;
 
 public interface SettlementService {
-    ShowMyTotalPaymentResponse getMyTotalPayments(Long userId, Long travelId, Long settlementRequestId);
+    ShowSettlementDetailResponse getSettlementDetails(Long userId, Long travelId, Long settlementRequestId);
 
 }

--- a/src/main/java/withbeetravel/service/settlement/SettlementService.java
+++ b/src/main/java/withbeetravel/service/settlement/SettlementService.java
@@ -1,0 +1,8 @@
+package withbeetravel.service.settlement;
+
+import withbeetravel.dto.settlement.ShowMyTotalPaymentResponse;
+
+public interface SettlementService {
+    ShowMyTotalPaymentResponse getMyTotalPayments(Long userId, Long travelId, Long settlementRequestId);
+
+}

--- a/src/main/java/withbeetravel/service/settlement/SettlementServiceImpl.java
+++ b/src/main/java/withbeetravel/service/settlement/SettlementServiceImpl.java
@@ -2,8 +2,10 @@ package withbeetravel.service.settlement;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import withbeetravel.domain.SharedPayment;
 import withbeetravel.domain.TravelMember;
 import withbeetravel.domain.TravelMemberSettlementHistory;
+import withbeetravel.dto.settlement.ShowMyDetailPaymentResponse;
 import withbeetravel.dto.settlement.ShowMyTotalPaymentResponse;
 import withbeetravel.dto.settlement.ShowOtherSettlementResponse;
 import withbeetravel.dto.settlement.ShowSettlementDetailResponse;
@@ -59,8 +61,24 @@ public class SettlementServiceImpl implements SettlementService{
                         })
                         .collect(Collectors.toList());
 
-        return null;
-    }
+        List<ShowMyDetailPaymentResponse> myDetailPayments =
+                paymentParticipatedMemberRepository.findAllByTravelMemberId(myTravelMemberId)
+                        .stream()
+                        .map(paymentParticipatedMember -> {
+                            SharedPayment sharedPayment = paymentParticipatedMember.getSharedPayment();
+                            int participantCount = sharedPayment.getParticipantCount();
+                            int paymentAmount = sharedPayment.getPaymentAmount();
+                            int requestedAmount = paymentAmount/participantCount;
+
+                            return ShowMyDetailPaymentResponse.of(
+                                    paymentAmount,
+                                    requestedAmount,
+                                    sharedPayment.getStoreName(),
+                                    sharedPayment.getPaymentDate());
+                        })
+                        .collect(Collectors.toList());
+
+        return ShowSettlementDetailResponse.of(myTotalPayments, myDetailPayments, others);    }
 
     private Long findMyTravelMemberIdByUserIdAndTravelId(Long userId, Long travelId) {
         TravelMember userTravelMember =

--- a/src/main/java/withbeetravel/service/settlement/SettlementServiceImpl.java
+++ b/src/main/java/withbeetravel/service/settlement/SettlementServiceImpl.java
@@ -1,0 +1,31 @@
+package withbeetravel.service.settlement;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import withbeetravel.domain.TravelMember;
+import withbeetravel.dto.settlement.ShowMyTotalPaymentResponse;
+import withbeetravel.exception.CustomException;
+import withbeetravel.repository.*;
+
+
+import static withbeetravel.exception.error.SettlementErrorCode.SETTLEMENT_NOT_FOUND;
+import static withbeetravel.exception.error.TravelErrorCode.TRAVEL_ACCESS_FORBIDDEN;
+import static withbeetravel.exception.error.TravelErrorCode.TRAVEL_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementServiceImpl implements SettlementService{
+
+    private final TravelRepository travelRepository;
+    private final TravelMemberRepository travelMemberRepository;
+    private final SettlementRequestRepository settlementRequestRepository;
+
+    @Override
+    public ShowMyTotalPaymentResponse getMyTotalPayments(Long userId, Long travelId, Long settlementRequestId) {
+        travelRepository.findById(travelId).orElseThrow(() -> new CustomException(TRAVEL_NOT_FOUND));
+        TravelMember travelMember = travelMemberRepository.findByUserIdAndTravelId(userId, travelId).orElseThrow(() -> new CustomException(TRAVEL_ACCESS_FORBIDDEN));
+        settlementRequestRepository.findById(settlementRequestId).orElseThrow(() -> new CustomException(SETTLEMENT_NOT_FOUND));
+
+        return null;
+    }
+}

--- a/src/main/java/withbeetravel/service/settlement/SettlementServiceImpl.java
+++ b/src/main/java/withbeetravel/service/settlement/SettlementServiceImpl.java
@@ -3,29 +3,72 @@ package withbeetravel.service.settlement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import withbeetravel.domain.TravelMember;
+import withbeetravel.domain.TravelMemberSettlementHistory;
 import withbeetravel.dto.settlement.ShowMyTotalPaymentResponse;
+import withbeetravel.dto.settlement.ShowOtherSettlementResponse;
+import withbeetravel.dto.settlement.ShowSettlementDetailResponse;
 import withbeetravel.exception.CustomException;
+import withbeetravel.exception.error.SettlementErrorCode;
+import withbeetravel.exception.error.TravelErrorCode;
 import withbeetravel.repository.*;
 
-
-import static withbeetravel.exception.error.SettlementErrorCode.SETTLEMENT_NOT_FOUND;
-import static withbeetravel.exception.error.TravelErrorCode.TRAVEL_ACCESS_FORBIDDEN;
-import static withbeetravel.exception.error.TravelErrorCode.TRAVEL_NOT_FOUND;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class SettlementServiceImpl implements SettlementService{
 
-    private final TravelRepository travelRepository;
     private final TravelMemberRepository travelMemberRepository;
     private final SettlementRequestRepository settlementRequestRepository;
+    private final TravelMemberSettlementHistoryRepository travelMemberSettlementHistoryRepository;
+    private final PaymentParticipatedMemberRepository paymentParticipatedMemberRepository;
 
     @Override
-    public ShowMyTotalPaymentResponse getMyTotalPayments(Long userId, Long travelId, Long settlementRequestId) {
-        travelRepository.findById(travelId).orElseThrow(() -> new CustomException(TRAVEL_NOT_FOUND));
-        TravelMember travelMember = travelMemberRepository.findByUserIdAndTravelId(userId, travelId).orElseThrow(() -> new CustomException(TRAVEL_ACCESS_FORBIDDEN));
-        settlementRequestRepository.findById(settlementRequestId).orElseThrow(() -> new CustomException(SETTLEMENT_NOT_FOUND));
+    public ShowSettlementDetailResponse getSettlementDetails(Long userId, Long travelId, Long settlementRequestId) {
+        validateSettlement(settlementRequestId);
+        Long myTravelMemberId = findMyTravelMemberIdByUserIdAndTravelId(userId, travelId);
+
+        List<TravelMemberSettlementHistory> travelMemberSettlementHistories =
+                travelMemberSettlementHistoryRepository.findAllBySettlementRequestId(settlementRequestId);
+
+        ShowMyTotalPaymentResponse myTotalPayments =
+                travelMemberSettlementHistories
+                        .stream()
+                        .filter(history -> history.getTravelMember().getId().equals(myTravelMemberId))
+                        .findFirst()
+                        .map(history -> {
+                            int ownPaymentCost = history.getOwnPaymentCost();
+                            int actualBurdenCost = history.getActualBurdenCost();
+                            int totalPaymentCost = ownPaymentCost - actualBurdenCost;
+
+                            return ShowMyTotalPaymentResponse.of(totalPaymentCost, ownPaymentCost, actualBurdenCost);
+                        })
+                        .orElseThrow(() -> new CustomException(SettlementErrorCode.MEMBER_SETTLEMENT_HISTORY_NOT_FOUND));
+
+        List<ShowOtherSettlementResponse> others =
+                travelMemberSettlementHistories
+                        .stream()
+                        .filter(history -> !history.getTravelMember().getId().equals(myTravelMemberId))
+                        .map(history -> {
+                            Long travelMemberId = history.getTravelMember().getId();
+                            TravelMember travelMember = travelMemberRepository.findById(travelMemberId).orElseThrow(() -> new CustomException(TravelErrorCode.TRAVEL_ACCESS_FORBIDDEN));
+                            String memberName = travelMember.getUser().getName();
+                            int totalPaymentCost = history.getOwnPaymentCost() - history.getActualBurdenCost();
+                            return ShowOtherSettlementResponse.of(memberName, totalPaymentCost);
+                        })
+                        .collect(Collectors.toList());
 
         return null;
+    }
+
+    private Long findMyTravelMemberIdByUserIdAndTravelId(Long userId, Long travelId) {
+        TravelMember userTravelMember =
+                travelMemberRepository.findByUserIdAndTravelId(userId, travelId).orElseThrow(() -> new CustomException(TravelErrorCode.TRAVEL_ACCESS_FORBIDDEN));
+        return userTravelMember.getId();
+    }
+
+    private void validateSettlement(Long settlementRequestId) {
+        settlementRequestRepository.findById(settlementRequestId).orElseThrow(() -> new CustomException(SettlementErrorCode.SETTLEMENT_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 📋 연관된 이슈 번호

- close #37

## 🛠 구현 사항

- 지출 세부 내역 조회 API 구현하였습니다.

## 📚 변경 사항

- 내용을 적어주세요.

## 🏜 스크린샷

### postman
- travelMemberId = 1인 경우
<img width="927" alt="image" src="https://github.com/user-attachments/assets/550e6b54-7ff2-418a-a04a-4c1ae3474988">
- travelMemberId = 2인 경우 
<img width="838" alt="image" src="https://github.com/user-attachments/assets/0b34d207-121f-45b0-9f95-ccf4ad5f420b">
- travelMemberId = 3인 경우
<img width="840" alt="image" src="https://github.com/user-attachments/assets/19095710-5501-4c03-84d8-bfede8554aab">

### 테스트용 db
- SharedPayment 테이블 (travelMemberId List는 정산에 포함된 인원을 보여주기 위해 임의로 넣음)
<img width="756" alt="image" src="https://github.com/user-attachments/assets/d2a1d203-90cb-4768-9ad8-35f77d6b8dac">

- TravelMember 테이블
<img width="585" alt="image" src="https://github.com/user-attachments/assets/1f68ee48-3045-42ec-976c-bf973eca97f0">

- Travel Settlement Member Histories 테이블
<img width="605" alt="image" src="https://github.com/user-attachments/assets/d4ccc99f-6b64-450c-871a-ddabe9460c8d">

## 💬 To Reviewers

- 피드백 부탁드려요!
