### PR TITLE
[feat/TK-175]: 핀번호 검증 API 구현 및 User 엔티티 수정

### DIFF
--- a/src/main/java/withbeetravel/controller/banking/VerifyController.java
+++ b/src/main/java/withbeetravel/controller/banking/VerifyController.java
@@ -1,0 +1,34 @@
+package withbeetravel.controller.banking;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import withbeetravel.dto.request.account.PinNumberRequest;
+import withbeetravel.dto.response.SuccessResponse;
+import withbeetravel.dto.response.account.PinNumberResponse;
+import withbeetravel.service.banking.VerifyService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/verify")
+public class VerifyController {
+
+    private final VerifyService verifyService;
+
+    @PostMapping("/pin-number")
+    public SuccessResponse verifyPin(
+            @RequestBody PinNumberRequest pinNumberRequest){
+        verifyService.verifyPin( pinNumberRequest.getPinNumber());
+
+        return SuccessResponse.of(HttpStatus.OK.value(), "핀번호 검증 완료");
+    }
+
+    @GetMapping("/user-state")
+    public SuccessResponse<PinNumberResponse> verifyUser(){
+        return SuccessResponse.of(
+                HttpStatus.OK.value(),
+                "유저가 잠금상태가 아닙니다.",
+                verifyService.verifyUser()
+        );
+    }
+}

--- a/src/main/java/withbeetravel/dto/request/account/PinNumberRequest.java
+++ b/src/main/java/withbeetravel/dto/request/account/PinNumberRequest.java
@@ -1,0 +1,8 @@
+package withbeetravel.dto.request.account;
+
+import lombok.Getter;
+
+@Getter
+public class PinNumberRequest {
+    private String pinNumber;
+}

--- a/src/main/java/withbeetravel/dto/response/account/PinNumberResponse.java
+++ b/src/main/java/withbeetravel/dto/response/account/PinNumberResponse.java
@@ -1,0 +1,11 @@
+package withbeetravel.dto.response.account;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PinNumberResponse {
+    private int failedPinCount;
+    private boolean pinLocked;
+}

--- a/src/main/java/withbeetravel/exception/error/BankingErrorCode.java
+++ b/src/main/java/withbeetravel/exception/error/BankingErrorCode.java
@@ -30,6 +30,9 @@ public class BankingErrorCode extends ErrorCode{
     public static final BankingErrorCode INVALID_PIN_NUMBER
             = new BankingErrorCode(HttpStatus.BAD_REQUEST, "INVALID_PIN_NUMBER", "BANKING-009", "잘못된 핀 번호입니다");
 
+    public static final BankingErrorCode ACCOUNT_LOCKED
+            = new BankingErrorCode(HttpStatus.LOCKED, "ACCOUNT_LOCKED", "BANKING-010", "계정이 잠겼습니다. PIN 재설정이 필요합니다");
+
     public BankingErrorCode(HttpStatus status,
                             String name, String code, String message) {
         super(status, name, code, message);

--- a/src/main/java/withbeetravel/service/banking/VerifyService.java
+++ b/src/main/java/withbeetravel/service/banking/VerifyService.java
@@ -1,0 +1,9 @@
+package withbeetravel.service.banking;
+
+import withbeetravel.dto.response.account.PinNumberResponse;
+
+public interface VerifyService {
+    public void verifyPin(String pin);
+
+    public PinNumberResponse verifyUser();
+}

--- a/src/main/java/withbeetravel/service/banking/VerifyServiceImpl.java
+++ b/src/main/java/withbeetravel/service/banking/VerifyServiceImpl.java
@@ -1,0 +1,56 @@
+package withbeetravel.service.banking;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import withbeetravel.domain.User;
+import withbeetravel.dto.response.account.PinNumberResponse;
+import withbeetravel.exception.CustomException;
+import withbeetravel.exception.error.AuthErrorCode;
+import withbeetravel.exception.error.BankingErrorCode;
+import withbeetravel.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class VerifyServiceImpl implements VerifyService{
+
+    private final UserRepository userRepository;
+
+    // TODO: 로그인 정보로 그에맞는 회원 id로 검증해야함
+
+    public void verifyPin(String pin){
+        User user = userRepository.findById(1L)
+                .orElseThrow(()-> new CustomException(AuthErrorCode.AUTHENTICATION_FAILED));
+
+        if (user.isPinLocked()) {
+            throw new CustomException(BankingErrorCode.ACCOUNT_LOCKED);
+        }
+
+        if (!user.validatePin(pin)) {
+            user.incrementFailedPinCount();
+            saveUser(user); // 저장 후 예외 던지기
+            throw new CustomException(BankingErrorCode.INVALID_PIN_NUMBER);
+        }
+
+        user.resetFailedPinCount();
+        userRepository.save(user);
+    }
+
+    // 예외가 발생하더라도 저장되야함 유저 실패 횟수를 늘리고 저장
+    @Transactional
+    private void saveUser(User user) {
+        userRepository.save(user);
+    }
+
+    // TODO: 여기도 회원 id 받아서 처리해야함 일단 1번인 유저로 확인하게 했음
+    public PinNumberResponse verifyUser(){
+        User user = userRepository.findById(1L)
+                .orElseThrow(()-> new CustomException(AuthErrorCode.AUTHENTICATION_FAILED));
+
+        if(user.isPinLocked()){
+            throw new CustomException(BankingErrorCode.ACCOUNT_LOCKED);
+        }
+        return new PinNumberResponse(user.getFailedPinCount(), user.isPinLocked());
+    }
+
+}


### PR DESCRIPTION
## 📋 연관된 이슈 번호

- close #85
## 🛠 구현 사항

- 핀번호 암호화 저장 및 암호화 된 것으로 비교
- 핀번호 검증 API 구현
- 핀번호 틀린 횟수 카운트 API 작성
- 뱅킹 에러코드 추가(핀번호 잠금 상태)

## 📚 변경 사항

- 유저 엔티티 수정(erd클라우드에도 수정 완) - 

## 🏜 스크린샷

- 프론트 참고 바랍니다.

## 💬 To Reviewers

- 전달할 사항들을 적어주세요.
