### PR TITLE
[Feat/TK-247] refresh token 삭제 스케줄러 구현

### DIFF
--- a/src/main/java/withbeetravel/exception/error/AuthErrorCode.java
+++ b/src/main/java/withbeetravel/exception/error/AuthErrorCode.java
@@ -24,6 +24,7 @@ public class AuthErrorCode extends ErrorCode{
     public static final AuthErrorCode INVALID_REFRESH_TOKEN = new AuthErrorCode(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "AUTH-016", "잘못된 리프레시 토큰");
     public static final AuthErrorCode USER_NOT_FOUND = new AuthErrorCode(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "AUTH-017", "사용자를 찾을 수 없음");
     public static final AuthErrorCode VALIDATION_FAILED = new AuthErrorCode(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "AUTH-018", "유효성 검사 실패");
+    public static final AuthErrorCode SCHEDULER_PROCESSING_FAILED = new AuthErrorCode(HttpStatus.UNPROCESSABLE_ENTITY, "SCHEDULER_PROCESSING_FAILED", "AUTH-019", "리프레시 토큰 삭제 스케줄링 중 오류가 발생했습니다.");
 
     private AuthErrorCode(HttpStatus status, String name, String code, String message) {
         super(status, name, code, message);

--- a/src/main/java/withbeetravel/repository/RefreshTokenRepository.java
+++ b/src/main/java/withbeetravel/repository/RefreshTokenRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import withbeetravel.domain.RefreshToken;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
@@ -18,4 +19,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByToken(String token);
 
     void deleteByToken(String token);
+
+    void deleteAllByExpirationTimeBefore(LocalDateTime localDateTime);
 }

--- a/src/main/java/withbeetravel/repository/RefreshTokenRepository.java
+++ b/src/main/java/withbeetravel/repository/RefreshTokenRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import withbeetravel.domain.RefreshToken;
 
-import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
@@ -20,5 +20,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     void deleteByToken(String token);
 
-    void deleteAllByExpirationTimeBefore(LocalDateTime localDateTime);
+    void deleteAllByExpirationTimeBefore(Date date);
 }

--- a/src/main/java/withbeetravel/scheduler/RefreshTokenScheduler.java
+++ b/src/main/java/withbeetravel/scheduler/RefreshTokenScheduler.java
@@ -1,0 +1,25 @@
+package withbeetravel.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import withbeetravel.exception.CustomException;
+import withbeetravel.exception.error.AuthErrorCode;
+import withbeetravel.service.auth.AuthService;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenScheduler {
+
+    private final AuthService authService;
+
+    @Scheduled(cron = "0 0 2 * * ?", zone = "Asia/Seoul")
+    public void deleteExpiredToken() {
+        try {
+            authService.deleteExpiredToken();
+        } catch (Exception e) {
+            throw new CustomException(AuthErrorCode.SCHEDULER_PROCESSING_FAILED);
+        }
+    }
+
+}

--- a/src/main/java/withbeetravel/service/auth/AuthService.java
+++ b/src/main/java/withbeetravel/service/auth/AuthService.java
@@ -18,4 +18,6 @@ public interface AuthService {
     void logout(final String refreshToken);
 
     MyPageResponse getMyPageInfo(Long userId);
+
+    void deleteExpiredToken();
 }

--- a/src/main/java/withbeetravel/service/auth/AuthServiceImpl.java
+++ b/src/main/java/withbeetravel/service/auth/AuthServiceImpl.java
@@ -149,7 +149,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public void deleteExpiredToken() {
-        refreshTokenRepository.deleteAllByExpirationTimeBefore(LocalDateTime.now());
+        refreshTokenRepository.deleteAllByExpirationTimeBefore(new Date());
     }
 
     private void checkRefreshToken(final String refreshToken) {

--- a/src/main/java/withbeetravel/service/auth/AuthServiceImpl.java
+++ b/src/main/java/withbeetravel/service/auth/AuthServiceImpl.java
@@ -18,6 +18,7 @@ import withbeetravel.jwt.TokenStatus;
 import withbeetravel.repository.RefreshTokenRepository;
 import withbeetravel.repository.UserRepository;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import static java.util.Objects.isNull;
@@ -144,6 +145,11 @@ public class AuthServiceImpl implements AuthService {
         User user = getUser(userId);
 
         return MyPageResponse.from(user);
+    }
+
+    @Override
+    public void deleteExpiredToken() {
+        refreshTokenRepository.deleteAllByExpirationTimeBefore(LocalDateTime.now());
     }
 
     private void checkRefreshToken(final String refreshToken) {


### PR DESCRIPTION
## 📋 연관된 이슈 번호

- close #145 

## 🛠 구현 사항

- refresh token의 만료일이 오늘 날짜보다 이전인 경우 삭제하는 스케줄러를 구현하였습니다.
- 해당 스케줄러는 매일 새벽 2시에 실행됩니다!

## 📚 변경 사항

## 🏜 스크린샷

- 테스트를 위해 스케줄러의 실행 시간을 매일 오전 10시 58분으로 변경하였습니다. (테스트 시작 시간은 오전 10시 57분)
- 스케줄러 이전 이후 db 변경 사항 (노란색으로 표시한 토큰이 오늘 날짜 이전에 만료된 리프레시 토큰 입니다.)
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/73005062-0a82-4fde-9341-d0b963c61f5c">

## 💬 To Reviewers

- 피드백 부탁드립니다!